### PR TITLE
fix: /products resource no longer fails on ZeroDivisionError

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,8 +62,12 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
-        return avg
+        try:                
+            avg = total_rating / len(ratings)
+            return avg
+
+        except ZeroDivisionError:
+            pass
 
     class Meta:
         verbose_name = ("product")

--- a/bangazonapi/models/productrating.py
+++ b/bangazonapi/models/productrating.py
@@ -7,7 +7,7 @@ class ProductRating(models.Model):
 
     product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="ratings")
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
-    rating = models.IntegerField(validators=[MinValueValidator(0), MaxValueValidator(5)])
+    rating = models.IntegerField(validators=[MinValueValidator(1), MaxValueValidator(5)])
 
 class Meta:
     verbose_name = ("productrating")

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -428,7 +428,7 @@ class FavoriteUserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
         fields = ('first_name', 'last_name', 'username')
-        depth = 1
+        # depth = 1
 
 
 class FavoriteSellerSerializer(serializers.HyperlinkedModelSerializer):
@@ -443,7 +443,7 @@ class FavoriteSellerSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Customer
         fields = ('id', 'url', 'user',)
-        depth = 1
+        # depth = 1
 
 
 class FavoriteSerializer(serializers.HyperlinkedModelSerializer):
@@ -458,4 +458,4 @@ class FavoriteSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Favorite
         fields = ('id', 'seller')
-        depth = 2
+        # depth = 2


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes
- IMPORTANT: PR addresses two issues:
- 1. Fixed zero division error on /products resource by adding a ZeroDivisionException block
- 2. Fixed listing error when querying /paymenttypes so only those relevant to the authenticated user, rather than every user, are returned.


# FIRST ISSUE
## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products` returns list without error



**Response**

HTTP/1.1 200 OK

```json
{
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Onguday",
        "image_path": null,
        "average_rating": null
    },
```

## Testing

Description of how to test code...

- [ ] send fetch to /products resource

# SECOND ISSUE 
## Given Code:
```

def list(self, request):
        """Handle GET requests to payment type resource"""
        payment_types = Payment.objects.all()
        customer_id = self.request.query_params.get('customer', None)
        if customer_id is not None:
            payment_types = payment_types.filter(customer__id=customer_id)
        serializer = PaymentSerializer(
            payment_types, many=True, context={'request': request})
        return Response(serializer.data)
```
Fix: deleted ```query_params``` because the fetch is to ```/paymenttypes``` without including an id value; changed ```objects.all()``` to ```objects.filter()``` where ```payment_types``` is set.

## Testing:
-[] send fetch to ```/paymenttypes``` using several different tokens to verify only their relevant entries are returned

## Related Issues

- Fixes #15
- Fixes #18 
